### PR TITLE
Update license URL

### DIFF
--- a/progressbutton/build.gradle.kts
+++ b/progressbutton/build.gradle.kts
@@ -48,7 +48,7 @@ publishing {
                 licenses {
                     license {
                         name.set("MIT")
-                        url.set("https://github.com/ioki-mobility/ProgressButton/blob/main/LICENSE")
+                        url.set("https://opensource.org/licenses/MIT")
                     }
                 }
                 organization {


### PR DESCRIPTION
The license URL should point to the "original license" defined by the [spdx license specification](https://spdx.org/licenses/).

