### PR TITLE
Dependabot: Group kotlin and compose compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
         interval: "weekly"
       registries:
         - maven-google
+      groups:
+        kotlin-compose:
+          patterns:
+            - "org.jetbrains.kotlin.android*"
+            - "androidx.compose.compiler*"
 
     - package-ecosystem: "github-actions"
       directory: "/"


### PR DESCRIPTION
Fixes #62 